### PR TITLE
fix bug: signature = nil

### DIFF
--- a/UpYunSDK/UpYun.m
+++ b/UpYunSDK/UpYun.m
@@ -275,9 +275,7 @@
     NSString *policy = [self getPolicyWithSaveKey:savekey];
     __block NSString *signature = @"";
     if (_signatureBlocker) {
-        dispatch_async(dispatch_get_main_queue(), ^(){
-            signature = _signatureBlocker([policy stringByAppendingString:@"&"]);
-        });
+        signature = _signatureBlocker([policy stringByAppendingString:@"&"]);
     } else if (self.passcode.length > 0) {
         signature = [self getSignatureWithPolicy:policy];
     } else {


### PR DESCRIPTION
使用signature校验时， _signatureBlocker异步会造成signature = nil的问题，因为已经执行到
    [multiBody addDictionary:@{@"policy":policy, @"signature":signature}]，此时signature为空，因此去除异步
