### PR TITLE
添加自定义 policy 传值

### DIFF
--- a/UpYunSDK/UpYun.h
+++ b/UpYunSDK/UpYun.h
@@ -66,6 +66,11 @@ typedef NSString*(^UPSignatureBlock)(NSString *policy);
 
 @property (nonatomic, assign) UPUploadMethod uploadMethod;
 
+/**
+ * 自定义policy
+ */
+@property (nonatomic, copy) NSString *policy;
+
 
 #ifdef __IPHONE_9_1
 /**

--- a/UpYunSDK/UpYun.m
+++ b/UpYunSDK/UpYun.m
@@ -370,9 +370,7 @@
     
     __block NSString *signature = @"";
     if (_signatureBlocker) {
-        dispatch_async(dispatch_get_main_queue(), ^(){
-            signature = _signatureBlocker(policy);
-        });
+        signature = _signatureBlocker(policy);
     } else if (self.passcode) {
         NSArray *keys = [[mutableDic allKeys] sortedArrayUsingSelector:@selector(compare:)];
         for (NSString * key in keys) {

--- a/UpYunSDK/UpYun.m
+++ b/UpYunSDK/UpYun.m
@@ -272,7 +272,7 @@
         }
     };
     
-    NSString *policy = [self getPolicyWithSaveKey:savekey];
+    NSString *policy = self.policy.length > 0 ? self.policy : [self getPolicyWithSaveKey:savekey];
     __block NSString *signature = @"";
     if (_signatureBlocker) {
         signature = _signatureBlocker([policy stringByAppendingString:@"&"]);


### PR DESCRIPTION
- 当使用服务端计算signature时，sdk依然自行计算policy，而且signature与policy都会验证。因语言等可能其他原因，即使使用一样的expiration页可能造成严重失败，故强烈建议可以自定义policy参数策略，policy也可以有服务端生成，客户端自定义赋值。

**
- policy异常原因 
  `- (NSString *)getPolicyWithSaveKey:(NSString *)savekey {
  NSMutableDictionary *dic = [NSMutableDictionary dictionary];
  [dic setObject:self.bucket forKey:@"bucket"];
  [dic setObject:DATE_STRING(self.expiresIn) forKey:@"expiration"];
  if (savekey && ![savekey isEqualToString:@""]) {
      [dic setObject:savekey forKey:@"save-key"];
  }...............`

由于 NSMutableDictionary 是不按插入顺序排序的，因此生成的自动顺序并不是 "bucket" "expiration" "save-key"，而是 "bucket""save-key" "expiration" ，因此与服务端不同，

---
- 是否是服务端计算signature后，客户端return signature，又拍就不需要验证policy，只是验证signature。

**
- 之前的signature=nil问题以及这个问题，分块上传的同样也存在此情况，因为暂时没使用，故没修改，希望能一并修改，谢谢
